### PR TITLE
Some clarifications in README.md

### DIFF
--- a/examples/betterApp.lean
+++ b/examples/betterApp.lean
@@ -3,6 +3,10 @@ open Qq
 
 set_option trace.compiler.ir.result true in
 
+-- Note: `betterApp` actually has two additional parameters
+-- `{u v : Lean.Level}` auto-generated due to option
+-- `autoBoundImplicitLocal`.
+
 def betterApp {α : Q(Sort u)} {β : Q($α → Sort v)}
   (f : Q((a : $α) → $β a)) (a : Q($α)) : Q($β $a) :=
 q($f $a)


### PR DESCRIPTION
Although I had some suggestions in mind, I didn't get them to work quite the way I wanted to, so here are just some minor changes to the readme.

Let me write a few words about the suggestions I had in mind though, in case they might be useful.
They boil down to two ideas:
* `quote4` contains two aspects that would benefit from keeping them a bit more separate, I think: typed expressions and quotation. In particular, `QQ` isn't really related to quotation at all, and IMHO it is useful in a more general way. Not sure how realistic this is, but IMHO it would be really beneficial (both for writers of meta code and for Lean itself) if it was used in the Lean code itself, replacing raw `Expr`.
* `QQ` can be inserted automatically where a type is expected, via `CoeSort`. Then the two quotation macros can be merged into one, which IMHO is a better fit for the concept that types are also terms. I've found that in most cases, this already works without any code changes, so I've experimentally implemented it in [my own code](https://github.com/SReichelt/universe-abstractions/blob/50b7c499d137e31457b8f276e1a024e0c5cd6dc4/UniverseAbstractions/Meta/TypedExpr.lean#L64). Unfortunately, there are a few cases where `Q(x)` works but (coerced) `q(x)` doesn't, which is why there are still some occurrences of `Q` in the actual [tactic code](https://github.com/SReichelt/universe-abstractions/blob/main/UniverseAbstractions/Meta/Reflect.lean). But when it works, it looks like [this](https://github.com/SReichelt/universe-abstractions/blob/50b7c499d137e31457b8f276e1a024e0c5cd6dc4/UniverseAbstractions/Meta/Reflect.lean#L108).

(BTW, the good news is that I was able to refactor all of my meta code to use `quote4`, and this improved the code quite a bit.)