### PR TITLE
Ensure shadowed variables are inaccessible in quotations

### DIFF
--- a/examples/shadowing.lean
+++ b/examples/shadowing.lean
@@ -1,0 +1,13 @@
+import Qq
+open Qq
+
+/-
+  This fails, the second definition of `n`, which is not of type `Nat`, shadows the first, 
+  `Nat`-typed, definition of `n`. 
+  Even if the second definition is not available inside the quotation (`Nat → Nat` does not implement `ToExpr`)
+  we don't want `$n` to refer to the shadowed definition, that would be confusing
+-/
+example : Q(Nat) :=
+  let n : Nat := 1
+  let n : Nat → Nat := fun _ => n
+  q($n)


### PR DESCRIPTION
Check which variables are shadowed in the meta-context, and make sure they are inaccessible in the quotation context (by making their `userName` hygienic).

This PR is motivated by the following example (the described behaviour is as it is for master):
```lean
import Qq
open Qq

def foo : Q(Nat) :=
  let n : Nat := 1

  -- Qq doesn't realize this is a `Nat`. so it doesn't incorporate it into the quotation context
  let n := 2 
  
  /-
    The context inside q(...) looks like:
      «$n»: Nat := 1
      ⊢ Nat
    Hence, `q($n)` is taken to mean `q(1)`, even though the user probably intended it to mean `q(2)`
  -/
  q($n)

example : foo = q(1) := rfl
```

After the PR, the context inside the quotation still only has the first version of `n`, but it's made inaccessible
```lean
$n✝: Nat := 1
⊢ Nat
```
So that the `q($n)` line will throw an `unknown identifier '«$n»'` error (which ideally would be an `the type of '«$n»' doesn'
t implement ToExpr` error, but that is a topic of a later PR).