### PR TITLE
chore: bump to nightly-2023-08-19

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-07-14
+leanprover/lean4:nightly-2023-08-19


### PR DESCRIPTION
I wouldn't usually do a bump here, as it is implicitly tested regularly by Mathlib, but `nightly-2023-08-19` is a tentative release candidate for the first official release of Lean 4, so it would be nice to try everything out on it explicitly!