### PR TITLE
fix: make goto definition work on quoted variables

### DIFF
--- a/Qq/Macro.lean
+++ b/Qq/Macro.lean
@@ -434,6 +434,8 @@ def quoteLCtx (ctx : LocalContext) (levelNames : List Name) :
     let quotedType ← quoteExpr type
     quotedCtx := quotedCtx.mkLocalDecl fid decl.userName
       (mkApp (mkConst ``Quoted) quotedType) decl.binderInfo
+    Elab.pushInfoLeaf <|
+      .ofFVarAliasInfo { id := fid, baseId := decl.fvarId, userName := decl.userName }
     assignments := assignments.push (toExpr (Expr.fvar decl.fvarId))
     if decl.isLet then
       let eqFid ← mkFreshFVarId


### PR DESCRIPTION
This follows up on #88

This also fixes semantic highlighting:
![image](https://github.com/user-attachments/assets/ac633987-b7d4-42ca-a8bb-a7ce4e716d95)
