### PR TITLE
perf: minimize imports

### DIFF
--- a/Qq/Commands.lean
+++ b/Qq/Commands.lean
@@ -1,7 +1,7 @@
 module
 
 public import Qq.Macro
-public import Lean.Meta.Eval
+public meta import Lean.Meta.Eval
 
 public section
 /-!

--- a/Qq/Commands.lean
+++ b/Qq/Commands.lean
@@ -1,10 +1,7 @@
 module
 
 public import Qq.Macro
-public import Lean
-meta import Lean.Elab.Term.TermElabM
-meta import Qq.Macro
-meta import Qq.AssertInstancesCommute
+public import Lean.Meta.Eval
 
 public section
 /-!

--- a/Qq/Delab.lean
+++ b/Qq/Delab.lean
@@ -1,7 +1,7 @@
 module
 
 public import Qq.Macro
-meta import Qq.Macro
+public import Qq.Typ
 
 public section
 /-!

--- a/Qq/ForLean/Do.lean
+++ b/Qq/ForLean/Do.lean
@@ -1,6 +1,6 @@
 module
 
-public import Lean
+public import Lean.Elab.Do.Legacy
 
 public section
 

--- a/Qq/ForLean/ReduceEval.lean
+++ b/Qq/ForLean/ReduceEval.lean
@@ -1,6 +1,6 @@
 module
 
-public import Lean
+public import Lean.Meta.ReduceEval
 
 public section
 open Lean Meta

--- a/Qq/ForLean/ToExpr.lean
+++ b/Qq/ForLean/ToExpr.lean
@@ -1,6 +1,6 @@
 module
 
-public import Lean
+public import Lean.ToExpr
 
 public section
 

--- a/Qq/Macro.lean
+++ b/Qq/Macro.lean
@@ -1,12 +1,10 @@
 module
 
-public import Lean
 public meta import Qq.ForLean.ReduceEval
 public meta import Qq.ForLean.ToExpr
 public meta import Qq.Typ
-meta import Lean.Elab.Term.TermElabM
-meta import Lean.Util.CollectLevelParams
-meta import Lean.Elab.SyntheticMVars
+public meta import Lean.Meta.CollectFVars
+public meta import Lean.Elab.SyntheticMVars
 
 public section
 /-!

--- a/Qq/Match.lean
+++ b/Qq/Match.lean
@@ -1,9 +1,7 @@
 module
 
-public import Qq.Macro
-public import Qq.MetaM
-public import Qq.ForLean.Do
-public import Qq.SortLocalDecls
+public meta import Qq.ForLean.Do
+public meta import Qq.SortLocalDecls
 public meta import Qq.MatchImpl
 
 public meta section

--- a/Qq/MatchImpl.lean
+++ b/Qq/MatchImpl.lean
@@ -1,10 +1,6 @@
 module
 
-public import Qq.Macro
 public import Qq.MetaM
-public import Qq.ForLean.Do
-public import Qq.SortLocalDecls
-import Qq.Typ
 
 public section
 

--- a/Qq/MetaM.lean
+++ b/Qq/MetaM.lean
@@ -1,8 +1,8 @@
 module
 
-public import Qq.Macro
 public import Qq.Delab
-import Qq.Typ
+import Lean.Meta.SynthInstance
+import Lean.Elab.Term.TermElabM
 
 public section
 

--- a/Qq/Simp.lean
+++ b/Qq/Simp.lean
@@ -1,6 +1,7 @@
 module
 
 public import Qq.MetaM
+public import Lean.Meta.Tactic.Simp.Types
 
 public section
 

--- a/Qq/Typ.lean
+++ b/Qq/Typ.lean
@@ -1,6 +1,6 @@
 module
 
-public import Lean
+public import Lean.Meta.Check
 
 public section
 open Lean

--- a/QqTest/hoMatching.lean
+++ b/QqTest/hoMatching.lean
@@ -1,4 +1,5 @@
 import Qq
+import Lean.Elab.Command
 open Qq Lean
 
 -- TODO: this linter crashes on the `def` below


### PR DESCRIPTION
In this PR I manually reduced the imports. The main goal is to remove plain `import Lean`, since this imports a lot more than is necessary.

This will help to speedup mathlib.