### PR TITLE
fix: Application type mismatch (was throwing after https://github.com/leanprover/lean4/pull/13030)

### DIFF
--- a/Qq/Delab.lean
+++ b/Qq/Delab.lean
@@ -71,7 +71,7 @@ meta def delabQuotedLevel : DelabM Syntax.Level := do
     StateT.run (s := { mayPostpone := false }) do
       unquoteLevelLCtx (addDefEqs := false)
       unquoteLevel e
-  return newE.quote max_prec
+  return newE.quote max_prec true (fun _ => none)
 
 @[delab app.Qq.Quoted]
 meta def delabQ : Delab := do


### PR DESCRIPTION
error message was

```
error: Qq/Delab.lean:74:9: Application type mismatch: The argument
 newE.quote 1024
has type
 (LMVarId → Option Nat) → Syntax.Level
but is expected to have type
 Syntax.Level
in the application
 pure (newE.quote 1024)
error: Lean exited with code 1
Some required targets logged failures:
- Qq.Delab
error: build failed
```