### PR TITLE
feat: wrapper components with `=Q`(`L`) hypotheses

### DIFF
--- a/Qq/Match.lean
+++ b/Qq/Match.lean
@@ -231,7 +231,7 @@ scoped elab "_qq_match" pat:term " ← " e:term " | " alt:term " in " body:term 
   let argLvlExpr ← mkFreshExprMVarQ q(Level)
   let argTyExpr ← mkFreshExprMVarQ q(Quoted (.sort $argLvlExpr))
   let e' ← elabTermEnsuringTypeQ e q(Quoted $argTyExpr)
-  let argTyExpr ← instantiateMVarsQ argTyExpr
+  let ⟨argTyExpr, _⟩ ← instantiateMVarsQ argTyExpr
 
   let ((lctx, localInsts, type), s) ← (unquoteForMatch argTyExpr).run { mayPostpone := (← read).mayPostpone }
   let (pat, patVarDecls, newLevels) ← elabPat pat lctx localInsts type s.levelNames

--- a/Qq/MetaM.lean
+++ b/Qq/MetaM.lean
@@ -116,3 +116,13 @@ def assertLevelDefEqQ (u v : Level) : MetaM (PLift (QuotedLevelDefEq u v)) := do
   match ← isLevelDefEqQ u v with
   | .defEq witness => return ⟨witness⟩
   | .notDefEq => throwError "{u} and {v} are not definitionally equal"
+
+set_option linter.unusedVariables false in
+def instantiateLevelsMVarsQ (u : Level) : MetaM { u' : Level // u =QL u' } :=
+  return ⟨← instantiateLevelMVars u, ⟨⟩⟩
+
+set_option linter.unusedVariables false in
+/-- Instantiate assigned universe metavariables in `u`, and then normalize it. -/
+def normalizeLevelQ (u : Level) : MetaM { u' : Level // u =QL u' } := do
+  let u ← instantiateLevelMVars u
+  pure ⟨u.normalize, ⟨⟩⟩

--- a/Qq/MetaM.lean
+++ b/Qq/MetaM.lean
@@ -35,8 +35,9 @@ def trySynthInstanceQ (α : Q(Sort u)) : MetaM (LOption Q($α)) := do
 def synthInstanceQ (α : Q(Sort u)) : MetaM Q($α) := do
   synthInstance α
 
-def instantiateMVarsQ {α : Q(Sort u)} (e : Q($α)) : MetaM Q($α) := do
-  instantiateMVars e
+/-- See `instantiateMVars`. Returns a definitional equality assumption. -/
+def instantiateMVarsQ {α : Q(Sort u)} (e : Q($α)) : MetaM { e' : Q($α) // $e =Q $e' } :=
+  return ⟨← instantiateMVars e, ⟨⟩⟩
 
 def elabTermEnsuringTypeQ (stx : Syntax) (expectedType : Q(Sort u))
     (catchExPostpone := true) (implicitLambda := true) (errorMsgHeader? : Option String := none) :

--- a/Qq/MetaM.lean
+++ b/Qq/MetaM.lean
@@ -39,6 +39,26 @@ def synthInstanceQ (α : Q(Sort u)) : MetaM Q($α) := do
 def instantiateMVarsQ {α : Q(Sort u)} (e : Q($α)) : MetaM { e' : Q($α) // $e =Q $e' } :=
   return ⟨← instantiateMVars e, ⟨⟩⟩
 
+/-- See `whnf`. Returns a definitional equality assumption. -/
+def whnfQ {α : Q(Sort u)} (e : Q($α)) : MetaM { e' : Q($α) // $e =Q $e' } :=
+  return ⟨← whnf e, ⟨⟩⟩
+
+/-- `whnfQ` with reducible transparency. Returns a definitional equality assumption. -/
+def whnfRQ {α : Q(Sort u)} (e : Q($α)) : MetaM { e' : Q($α) // $e =Q $e' } :=
+  return ⟨← whnfR e, ⟨⟩⟩
+
+/-- `whnfQ` with default transparency. Returns a definitional equality assumption. -/
+def whnfDQ {α : Q(Sort u)} (e : Q($α)) : MetaM { e' : Q($α) // $e =Q $e' } :=
+  return ⟨← whnfD e, ⟨⟩⟩
+
+/-- `whnfQ` with instances transparency. Returns a definitional equality assumption. -/
+def whnfIQ {α : Q(Sort u)} (e : Q($α)) : MetaM { e' : Q($α) // $e =Q $e' } :=
+  return ⟨← whnfD e, ⟨⟩⟩
+
+/-- `whnfQ` with at most instances transparency. Returns a definitional equality assumption. -/
+def whnfAtMostIQ {α : Q(Sort u)} (e : Q($α)) : MetaM { e' : Q($α) // $e =Q $e' } :=
+  return ⟨← whnfAtMostI e, ⟨⟩⟩
+
 def elabTermEnsuringTypeQ (stx : Syntax) (expectedType : Q(Sort u))
     (catchExPostpone := true) (implicitLambda := true) (errorMsgHeader? : Option String := none) :
     TermElabM Q($expectedType) := do


### PR DESCRIPTION
This PR changes the type signature of `instantiateMVarsQ` to return a definitional equality hypothesis relating the old expression to the new, and adds several other missing wrapper functions with the same pattern. Namely, `instantiateLevelMVarsQ`, `normalizeLevelQ`, and `Q` versions of the family of `whnf` functions. (Usually `whnf` is not necessary when handling Qq, but we may as well have coverage.)

---

Mathlib adaptations at leanprover-community/mathlib4#40090. (Seems like only one adaptation is needed so far.)
